### PR TITLE
Support rewrite s3 presign url

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,7 @@ class S3StorageSettings(BaseModel):
     access_key_id: str | None = None
     secret_access_key: str | None = None
     session_token: str | None = None
+    user_endpoint_url: str | None = None
 
 
 class LocalStorageSettings(BaseModel):

--- a/config/default.env
+++ b/config/default.env
@@ -109,3 +109,5 @@
 # APP_STORAGE__S3__SECRET_ACCESS_KEY="your-s3-secret-access-key"
 # Session token for accessing the S3 bucket (optional)
 # APP_STORAGE__S3__SESSION_TOKEN="your-s3-session-token"
+# Optional Endpoint URL for final presentation to the user
+# APP_STORAGE__S3__USER_ENDPOINT_URL="your-s3-user-endpoint-url"


### PR DESCRIPTION
The idea is to add a new configuration item user_endpoint_url in the image gallery. 
The requirement is to deploy using local S3 storage such as Minio, but without exposing Minio to the public internet. Instead, the goal is to use Nginx to reverse proxy the local image gallery and Minio URL.